### PR TITLE
Adds h2 database default web url

### DIFF
--- a/fuzz.txt
+++ b/fuzz.txt
@@ -1639,6 +1639,7 @@ guanli/admin.asp
 Guardfile
 gulpfile.coffee
 gulpfile.js
+h2console
 HISTORY
 HNAP1/
 home.html


### PR DESCRIPTION
A somewhat common misconfiguration of h2 is to enable web access. In worst case leads to rce.