### PR TITLE
Adds restricted and read-only invoker

### DIFF
--- a/fuzz.txt
+++ b/fuzz.txt
@@ -1767,6 +1767,8 @@ installer-log.txt
 installer.php
 install~/
 invoker/JMXInvokerServlet
+invoker/restricted/JMXInvokerServlet
+invoker/readonly/JMXInvokerServlet
 irc-macadmin/
 isadmin
 isadmin.php


### PR DESCRIPTION
1. Userful to bypass url-based restrictions:
2. Readonly invoker by default has no authorization and might be vulnerable to deserialization [1]

[1] https://seanmelia.wordpress.com/2016/07/22/exploiting-java-deserialization-via-jboss/