### PR TITLE
Insert _wl_cls_gen.jar

### DIFF
--- a/fuzz.txt
+++ b/fuzz.txt
@@ -4727,6 +4727,8 @@ WEB-INF./web.xml
 WEB-INF/
 WEB-INF/config.xml
 WEB-INF/web.xml
+WEB-INF/lib/_wl_cls_gen.jar
+_wl_cls_gen.jar
 web-variables.env
 web.7z
 web.config


### PR DESCRIPTION
This file are created when you setup/deploy the Oracle Web Logic Server. This have a lot of .class  (after decompile with Jadx tool or jd-gui) from the target site, you can get a lot of vulns :)